### PR TITLE
TakeScreenshotOnFailureRunListener is not removed after successful test case

### DIFF
--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -265,12 +265,21 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
                     DriverPathLoader.loadDriverPaths(getTestClass().getJavaClass().getAnnotation(DriverPaths.class));
                 }
 
-                if (hasTakeScreenshotOnFailureAnnotation(getTestClass())) {
+                boolean hasTakeScreenshotOnFailureAnnotation = hasTakeScreenshotOnFailureAnnotation(getTestClass());
+                TakeScreenshotOnFailureRunListener screenshotRunListener = null;
+
+                if (hasTakeScreenshotOnFailureAnnotation) {
                     String fileName = className + "." + methodName;
-                    notifier.addListener(new TakeScreenshotOnFailureRunListener(log, fileName));
+                    screenshotRunListener = new TakeScreenshotOnFailureRunListener(log, fileName);
+                    notifier.addListener(screenshotRunListener);
                 }
+
                 runLeaf(methodBlock(method), description, notifier);
                 driver.quit();
+
+                if (hasTakeScreenshotOnFailureAnnotation)
+                    notifier.removeListener(screenshotRunListener);
+
                 WebDriverExtensionsContext.removeDriver();
             }
         } else {


### PR DESCRIPTION
When running multiple test cases in one class and one test case fails, depending on the amount of TakeScreenshotOnFailureRunListener objects added to the RunNotifier, multiple screenshots will be taken (with other test case method names in the image name).

This is because the listeners are added and kept inside the RunListener list.