### PR TITLE
Fixes issue with wrong test description when using JUnit 4.12 and above.

### DIFF
--- a/src/main/java/com/github/webdriverextensions/internal/utils/WebDriverUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/WebDriverUtils.java
@@ -98,7 +98,7 @@ public class WebDriverUtils {
                 || extension.equals("png")) {
             return filename;
         } else {
-            return filename + ".png";
+            return filename + ".jpg";
         }
     }
 

--- a/src/main/java/com/github/webdriverextensions/internal/utils/WebDriverUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/WebDriverUtils.java
@@ -98,7 +98,7 @@ public class WebDriverUtils {
                 || extension.equals("png")) {
             return filename;
         } else {
-            return filename + ".jpg";
+            return filename + ".png";
         }
     }
 

--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -288,6 +288,12 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
         }
     }
 
+    @Override
+    protected Description describeChild(FrameworkMethod method) {
+        return Description.createTestDescription(getTestClass().getJavaClass(),
+                testName(method), method.getAnnotations());
+    }
+
     private class TestMethodContext {
 
         List<BrowserConfiguration> browsers = new ArrayList<BrowserConfiguration>();


### PR DESCRIPTION
With JUnit 4.12 and above the org.junit.runners.BlockJUnit4ClassRunner#describeChild method caches the created method description. This leads to several issues when using the WebDriverRunner:
* Test methods are named same even when related to different browsers
* Screenshot files are only stored once since the screenshot name is based on test method description.

The JUnit change can be seen here: https://github.com/junit-team/junit/commit/08719e9b61d07c17b6a4f599ecd2cd1a1519120a

This change restores the original behavior by overriding describeChild method in WebDriverRunner!