### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/com/github/webdriverextensions/Bot.java
+++ b/src/main/java/com/github/webdriverextensions/Bot.java
@@ -34,6 +34,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.BrowserType;
 
 public class Bot {
+    
+    private Bot() {}
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Bot.class);
 

--- a/src/main/java/com/github/webdriverextensions/WebDriverExtensionsContext.java
+++ b/src/main/java/com/github/webdriverextensions/WebDriverExtensionsContext.java
@@ -5,6 +5,8 @@ import org.openqa.selenium.WebDriver;
 
 public class WebDriverExtensionsContext {
 
+    private WebDriverExtensionsContext() {}
+    
     private static InheritableThreadLocal<WebDriver> threadLocalDriver = new InheritableThreadLocal<WebDriver>();
 
     public static WebDriver getDriver() {

--- a/src/main/java/com/github/webdriverextensions/internal/BotUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/BotUtils.java
@@ -9,6 +9,8 @@ import org.openqa.selenium.WebElement;
 
 public class BotUtils {
 
+    private BotUtils() {}
+    
     /* Html */
     public static String htmlOf(WebElement webElement) {
         if (webElement == null) {

--- a/src/main/java/com/github/webdriverextensions/internal/ReflectionUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/ReflectionUtils.java
@@ -13,6 +13,8 @@ import org.openqa.selenium.support.pagefactory.ElementLocator;
 
 public class ReflectionUtils {
 
+    private ReflectionUtils() {}
+    
     public static ElementLocator getLocator(WebElement webElement) {
         try {
             Field locatorField = webElement.getClass().getDeclaredField("locator");

--- a/src/main/java/com/github/webdriverextensions/internal/generator/ElementUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/generator/ElementUtils.java
@@ -6,6 +6,8 @@ import javax.lang.model.element.PackageElement;
 
 public class ElementUtils {
 
+    private ElementUtils() {}
+    
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ElementUtils.class);
 
     public static boolean isClass(Element element) {

--- a/src/main/java/com/github/webdriverextensions/internal/generator/GeneratorUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/generator/GeneratorUtils.java
@@ -23,6 +23,8 @@ import org.openqa.selenium.support.How;
 
 public class GeneratorUtils {
 
+    private GeneratorUtils() {}
+    
     public static void error(String msg, ProcessingEnvironment processingEnv) {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg);
     }

--- a/src/main/java/com/github/webdriverextensions/internal/junitrunner/DriverPathLoader.java
+++ b/src/main/java/com/github/webdriverextensions/internal/junitrunner/DriverPathLoader.java
@@ -7,6 +7,8 @@ import com.github.webdriverextensions.junitrunner.annotations.DriverPaths;
 
 public class DriverPathLoader {
 
+    private DriverPathLoader() {}
+    
     private static final String CHROME_DRIVER_PROPERTY_NAME = "webdriver.chrome.driver";
     private static final String IE_DRIVER_PROPERTY_NAME = "webdriver.ie.driver";
     private static final String INTERNET_EXPLORER_DRIVER_PROPERTY_NAME = "webdriver.internetexplorer.driver"; // Alternative property name that follows naming convention

--- a/src/main/java/com/github/webdriverextensions/internal/junitrunner/ScreenshotsPathLoader.java
+++ b/src/main/java/com/github/webdriverextensions/internal/junitrunner/ScreenshotsPathLoader.java
@@ -6,6 +6,8 @@ import com.github.webdriverextensions.junitrunner.annotations.ScreenshotsPath;
 
 public class ScreenshotsPathLoader {
 
+    private ScreenshotsPathLoader() {}
+    
     public static void loadScreenshotsPath(ScreenshotsPath screenshotsPathAnnotation) {
         String screenshotsPathAnnotationValue = screenshotsPathAnnotation != null ? screenshotsPathAnnotation.value() : null;
         PropertyUtils.setPropertyIfNotExists(SCREENSHOTSPATH_PROPERTY_NAME, screenshotsPathAnnotationValue);

--- a/src/main/java/com/github/webdriverextensions/internal/utils/FileUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/FileUtils.java
@@ -4,6 +4,8 @@ import java.io.File;
 
 public class FileUtils {
 
+    private FileUtils() {}
+    
     public static void makeExecutable(String path) {
         if (path == null) {
             return;

--- a/src/main/java/com/github/webdriverextensions/internal/utils/InstanceUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/InstanceUtils.java
@@ -5,6 +5,8 @@ import java.lang.reflect.InvocationTargetException;
 
 public class InstanceUtils {
 
+    private InstanceUtils() {}
+    
     public static <T> T newInstance(Class clazz, Class<T> returnedClazz) {
         try {
             return (T) clazz.getConstructor().newInstance();

--- a/src/main/java/com/github/webdriverextensions/internal/utils/NumberUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/NumberUtils.java
@@ -2,6 +2,8 @@ package com.github.webdriverextensions.internal.utils;
 
 public class NumberUtils {
 
+    private NumberUtils() {}
+    
     public static String toString(double number) {
         if (number == (int) number) {
             return String.format("%d", (int) number);

--- a/src/main/java/com/github/webdriverextensions/internal/utils/OsUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/OsUtils.java
@@ -4,6 +4,8 @@ import org.openqa.selenium.Platform;
 
 public class OsUtils {
 
+    private OsUtils() {}
+    
     public static boolean isWindows() {
         return Platform.getCurrent().is(Platform.WINDOWS);
     }

--- a/src/main/java/com/github/webdriverextensions/internal/utils/PropertyUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/PropertyUtils.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.BooleanUtils;
 
 public class PropertyUtils {
 
+    private PropertyUtils() {}
+    
     public static boolean isTrue(String key) {
         return BooleanUtils.toBoolean(System.getProperty(key));
     }

--- a/src/main/java/com/github/webdriverextensions/internal/utils/StringUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/StringUtils.java
@@ -3,6 +3,8 @@ package com.github.webdriverextensions.internal.utils;
 import static org.apache.commons.lang3.StringUtils.contains;
 
 public class StringUtils {
+    
+    private StringUtils() {}
 
     public static String appendNewLineIfContainsNewLine(String string) {
         if (contains(string, "\n")) {

--- a/src/main/java/com/github/webdriverextensions/internal/utils/WebDriverUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/utils/WebDriverUtils.java
@@ -20,6 +20,8 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 
 public class WebDriverUtils {
 
+    private WebDriverUtils() {}
+    
     public static String convertToJsonString(Capabilities capabilities) {
         if (capabilities == null) {
             return "{}";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed