### PR TITLE
General code quality fix-2

### DIFF
--- a/src/main/java/com/github/webdriverextensions/Bot.java
+++ b/src/main/java/com/github/webdriverextensions/Bot.java
@@ -579,7 +579,7 @@ public class Bot {
     }
 
     public static boolean sizeEquals(int number, Collection collection) {
-        return BotUtils.equals((double) number, (double) collection.size());
+        return BotUtils.isEqual((double) number, (double) collection.size());
     }
 
     public static boolean sizeNotEquals(int number, Collection collection) {
@@ -633,7 +633,7 @@ public class Bot {
     }
 
     public static boolean currentUrlEquals(String url) {
-        return BotUtils.equals(url, currentUrl());
+        return BotUtils.isEqual(url, currentUrl());
     }
 
     public static boolean currentUrlNotEquals(String url) {
@@ -720,7 +720,7 @@ public class Bot {
     }
 
     public static boolean titleEquals(String title) {
-        return BotUtils.equals(title, title());
+        return BotUtils.isEqual(title, title());
     }
 
     public static boolean titleNotEquals(String title) {
@@ -807,7 +807,7 @@ public class Bot {
     }
 
     public static boolean tagNameEquals(String value, WebElement webElement) {
-        return BotUtils.equals(value, tagNameOf(webElement));
+        return BotUtils.isEqual(value, tagNameOf(webElement));
     }
 
     public static boolean tagNameNotEquals(String value, WebElement webElement) {
@@ -860,7 +860,7 @@ public class Bot {
     }
 
     public static boolean attributeEquals(String name, String value, WebElement webElement) {
-        return BotUtils.equals(value, attributeIn(name, webElement));
+        return BotUtils.isEqual(value, attributeIn(name, webElement));
     }
 
     public static boolean attributeNotEquals(String name, String value, WebElement webElement) {
@@ -972,7 +972,7 @@ public class Bot {
     }
 
     public static boolean attributeEquals(String name, double number, WebElement webElement) {
-        return BotUtils.equals(number, attributeInAsNumber(name, webElement));
+        return BotUtils.isEqual(number, attributeInAsNumber(name, webElement));
     }
 
     public static boolean attributeNotEquals(String name, double number, WebElement webElement) {
@@ -1348,7 +1348,7 @@ public class Bot {
     public static boolean hasClass(String className, WebElement webElement) {
         List<String> classes = classesIn(webElement);
         for (String clazz : classes) {
-            if (BotUtils.equals(className, clazz)) {
+            if (BotUtils.isEqual(className, clazz)) {
                 return true;
             }
         }
@@ -1876,11 +1876,11 @@ public class Bot {
     }
 
     public static boolean hasNotText(WebElement webElement) {
-        return BotUtils.equals("", textIn(webElement));
+        return BotUtils.isEqual("", textIn(webElement));
     }
 
     public static boolean textEquals(String text, WebElement webElement) {
-        return BotUtils.equals(text, textIn(webElement));
+        return BotUtils.isEqual(text, textIn(webElement));
     }
 
     public static boolean textNotEquals(String text, WebElement webElement) {
@@ -2092,7 +2092,7 @@ public class Bot {
     }
 
     public static boolean textEquals(double number, WebElement webElement) {
-        return BotUtils.equals(number, textInAsNumber(webElement));
+        return BotUtils.isEqual(number, textInAsNumber(webElement));
     }
 
     public static boolean textNotEquals(double number, WebElement webElement) {

--- a/src/main/java/com/github/webdriverextensions/WebComponent.java
+++ b/src/main/java/com/github/webdriverextensions/WebComponent.java
@@ -262,6 +262,6 @@ public abstract class WebComponent implements org.openqa.selenium.WebElement, or
 
     @Override
     public <X> X getScreenshotAs(OutputType<X> ot) throws WebDriverException {
-        return ((org.openqa.selenium.WebElement) wrappedWebElement).getScreenshotAs(ot);
+        return wrappedWebElement.getScreenshotAs(ot);
     }
 }

--- a/src/main/java/com/github/webdriverextensions/internal/BotUtils.java
+++ b/src/main/java/com/github/webdriverextensions/internal/BotUtils.java
@@ -58,7 +58,7 @@ public class BotUtils {
 
 
     /* String Equals */
-    public static boolean equals(String text1, String text2) {
+    public static boolean isEqual(String text1, String text2) {
         return StringUtils.equals(text1, text2);
     }
 
@@ -144,7 +144,7 @@ public class BotUtils {
     }
 
     public static void assertNotEquals(String name, String notExpected, String actual) {
-        if (equals(notExpected, actual)) {
+        if (isEqual(notExpected, actual)) {
             throw new WebAssertionError(name + " is equal to " + quote(notExpected) + " when it shouldn't", name, actual);
         }
     }
@@ -204,7 +204,7 @@ public class BotUtils {
     }
 
     public static void assertNotEquals(String name, String notExpected, String actual, WebElement webElement) {
-        if (equals(notExpected, actual)) {
+        if (isEqual(notExpected, actual)) {
             throw new WebAssertionError(name + " is equal to " + quote(notExpected) + " when it shouldn't", webElement);
         }
     }
@@ -308,7 +308,7 @@ public class BotUtils {
 
 
     /* Double Equals */
-    public static boolean equals(double number, double actual) {
+    public static boolean isEqual(double number, double actual) {
         return actual == number;
     }
 
@@ -339,7 +339,7 @@ public class BotUtils {
     }
 
     public static void assertNotEquals(String name, double number, double actual) {
-        if (equals(number, actual)) {
+        if (isEqual(number, actual)) {
             throw new WebAssertionError(name + " is equal to " + quote(number) + " when it shouldn't", name, actual);
         }
     }
@@ -375,7 +375,7 @@ public class BotUtils {
     }
 
     public static void assertNotEquals(String name, double number, double actual, WebElement webElement) {
-        if (equals(number, actual)) {
+        if (isEqual(number, actual)) {
             throw new WebAssertionError(name + " is equal to " + quote(number) + " when it shouldn't", webElement);
         }
     }

--- a/src/main/java/com/github/webdriverextensions/internal/WebDriverExtensionAnnotations.java
+++ b/src/main/java/com/github/webdriverextensions/internal/WebDriverExtensionAnnotations.java
@@ -17,7 +17,7 @@ public class WebDriverExtensionAnnotations extends Annotations {
     }
 
     boolean isSearchContextReset() {
-        return (field.getAnnotation(ResetSearchContext.class) != null);
+        return field.getAnnotation(ResetSearchContext.class) != null;
     }
 
     public static WebElement getDelagate(WebComponent webComponent) {

--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -138,6 +138,9 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
         ScreenshotsPathLoader.loadScreenshotsPath(getTestClass().getJavaClass().getAnnotation(ScreenshotsPath.class));
     }
 
+    /**
+     * @deprecated retained for backward compatibility
+     */
     @Deprecated
     @Override
     protected void validateInstanceMethods(List<Throwable> errors) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1905 - Redundant casts should not be used
squid:S1201 - Methods named "equals" should override Object.equals(Object).
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S1201
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck

Please let me know if you have any questions.

Faisal Hameed