### PR TITLE
Controlling which browsers are to execute / ignore without code changes (JUnit)

### DIFF
--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -2,6 +2,7 @@ package com.github.webdriverextensions.junitrunner;
 
 import com.github.webdriverextensions.WebDriverExtensionFieldDecorator;
 import com.github.webdriverextensions.WebDriverExtensionsContext;
+import com.github.webdriverextensions.WebDriverProperties;
 import com.github.webdriverextensions.internal.WebDriverExtensionException;
 import com.github.webdriverextensions.internal.junitrunner.AnnotationUtils;
 import com.github.webdriverextensions.internal.junitrunner.DriverPathLoader;
@@ -47,6 +48,8 @@ import org.openqa.selenium.support.PageFactory;
 
 import java.lang.annotation.Annotation;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
First of all, thanks for your work on webdriverextensions, I really like it.

Is there a way of controlling which browsers are enabled during test execution without code changes? My use case is a CI build, which I would like to execute with Chrome only after every change in my code and with any browser in a nightly build since it takes much longer.

I extended the com.github.webdriverextensions.junitrunner.WebDriverRunner that takes a look at the system property "webdriverextensions.disabledbrowsers" to ignore browsers listed there.

This is only a suggestion/idea, there is probably a more elegant way of doing this.

Thanks and best regards
Alex