### PR TITLE
 #74 - disable browser by property

### DIFF
--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -123,9 +123,11 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
         return filteredTestAnnotatedMethods;
     }
 
-    private static List<String> getDisabledBrowsers() {
+    protected static List<String> getDisabledBrowsers() {
         String disabledBrowsersString = System.getProperty("webdriverextensions.disabledbrowsers", "");
-        return parseDisabledBrowserString(disabledBrowsersString);
+        List<String> disabledBrowsersList = parseDisabledBrowserString(disabledBrowsersString);
+	log.info("Browsers disabled by system property: {}", disabledBrowsersList);
+        return disabledBrowsersList;
     }
 
     protected static List<String> parseDisabledBrowserString(String disabledBrowsersString) {
@@ -133,7 +135,6 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
         for (String disabledbrowserString : disabledBrowsersString.split(",")) {
             if (StringUtils.isNotBlank(disabledbrowserString)) {
                 result.add(disabledbrowserString.trim());
-                System.out.println("disabled browser: " + disabledbrowserString);
             }
         }
 	return result;

--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -59,6 +59,7 @@ import static org.openqa.selenium.remote.CapabilityType.*;
 
 public class WebDriverRunner extends BlockJUnit4ClassRunner {
 
+    public static final String PROPERTY_DISABLED_BROWSERS = "webdriverextensions.disabledbrowsers";
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(WebDriverRunner.class);
     private static final List<String> disabledBrowsers = getDisabledBrowsers();
 
@@ -124,7 +125,7 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
     }
 
     protected static List<String> getDisabledBrowsers() {
-        String disabledBrowsersString = System.getProperty("webdriverextensions.disabledbrowsers", "");
+        String disabledBrowsersString = System.getProperty(PROPERTY_DISABLED_BROWSERS, "");
         List<String> disabledBrowsersList = parseDisabledBrowserString(disabledBrowsersString);
 	log.info("Browsers disabled by system property: {}", disabledBrowsersList);
         return disabledBrowsersList;

--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -125,14 +125,18 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
 
     private static List<String> getDisabledBrowsers() {
         String disabledBrowsersString = System.getProperty("webdriverextensions.disabledbrowsers", "");
-        List<String> result = new ArrayList<>();
+        return parseDisabledBrowserString(disabledBrowsersString);
+    }
+
+    protected static List<String> parseDisabledBrowserString(String disabledBrowsersString) {
+	List<String> result = new ArrayList<>();
         for (String disabledbrowserString : disabledBrowsersString.split(",")) {
             if (StringUtils.isNotBlank(disabledbrowserString)) {
                 result.add(disabledbrowserString);
                 System.out.println("disabled browser: " + disabledbrowserString);
             }
         }
-        return result;
+	return result;
     }
 
     public WebDriverRunner(Class<?> klass) throws InitializationError {

--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -132,7 +132,7 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
 	List<String> result = new ArrayList<>();
         for (String disabledbrowserString : disabledBrowsersString.split(",")) {
             if (StringUtils.isNotBlank(disabledbrowserString)) {
-                result.add(disabledbrowserString);
+                result.add(disabledbrowserString.trim());
                 System.out.println("disabled browser: " + disabledbrowserString);
             }
         }

--- a/src/test/java/com/github/webdriverextensions/junitrunner/DisabledBrowserTest.java
+++ b/src/test/java/com/github/webdriverextensions/junitrunner/DisabledBrowserTest.java
@@ -21,4 +21,10 @@ public class DisabledBrowserTest {
 	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox , chrome"), hasItem("firefox"));
 	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox , chrome"), hasItem("chrome"));
     }
+    
+    @Test
+    public void testGetDisabledBrowsers() {
+	System.setProperty("webdriverextensions.disabledbrowsers", "firefox");
+	assertThat(WebDriverRunner.getDisabledBrowsers().size(), is(1));
+    }
 }

--- a/src/test/java/com/github/webdriverextensions/junitrunner/DisabledBrowserTest.java
+++ b/src/test/java/com/github/webdriverextensions/junitrunner/DisabledBrowserTest.java
@@ -1,0 +1,24 @@
+package com.github.webdriverextensions.junitrunner;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+import org.junit.Test;
+
+public class DisabledBrowserTest {
+
+    @Test
+    public void testParseDisabledBrowserSring() {
+	assertThat(WebDriverRunner.parseDisabledBrowserString("").size(), is(0));
+
+	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox").size(), is(1));
+	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox"), hasItem("firefox"));
+	
+	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox,chrome").size(), is(2));
+	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox,chrome"), hasItem("firefox"));
+	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox,chrome"), hasItem("chrome"));
+    
+	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox , chrome").size(), is(2));
+	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox , chrome"), hasItem("firefox"));
+	assertThat(WebDriverRunner.parseDisabledBrowserString("firefox , chrome"), hasItem("chrome"));
+    }
+}

--- a/src/test/java/com/github/webdriverextensions/junitrunner/DisabledBrowserTest.java
+++ b/src/test/java/com/github/webdriverextensions/junitrunner/DisabledBrowserTest.java
@@ -24,7 +24,7 @@ public class DisabledBrowserTest {
     
     @Test
     public void testGetDisabledBrowsers() {
-	System.setProperty("webdriverextensions.disabledbrowsers", "firefox");
+	System.setProperty(WebDriverRunner.PROPERTY_DISABLED_BROWSERS, "firefox");
 	assertThat(WebDriverRunner.getDisabledBrowsers().size(), is(1));
     }
 }


### PR DESCRIPTION
I've done some unit testing and refactoring for this nice feature:
  * more relaxed parsing (allow `firefox, chrome` style if you escape the property setting)
  * logging using the logger instead of "syso"
  * log out that the browser is disabled because of a system property