### PR TITLE
Update phantomjs to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <logback.version>1.1.7</logback.version>
         <selenium.version>3.1.0</selenium.version>
         <htmlunit-driver.version>2.23</htmlunit-driver.version>
-        <phantomjsdriver.version>1.3.0</phantomjsdriver.version>
+        <phantomjsdriver.version>1.4.0</phantomjsdriver.version>
 
         <!-- Plugin Versions -->
         <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>


### PR DESCRIPTION
needed because a deprecated and now removed selenium method is used in 1.3.0