### PR TITLE
Override getDescription() so that correct Description is returned

### DIFF
--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -219,6 +219,16 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
         return testMethods;
     }
 
+    @Override
+    public Description getDescription() {
+        Description description = Description.createSuiteDescription(getName(),
+                getRunnerAnnotations());
+        for (FrameworkMethod child : getFilteredTestAnnotatedMethods()) {
+            description.addChild(describeChild(child));
+        }
+        return description;
+    }
+
     protected List<FrameworkMethod> getTestAnnotatedMethods() {
         List<FrameworkMethod> testAnnotatedMethods = getTestClass().getAnnotatedMethods(Test.class);
         List<FrameworkMethod> testMethods = new ArrayList<>();


### PR DESCRIPTION
Runner#getDescription is used to retrieve the methods for test execution and as ParentRunner and WebDriverRunner use different (private) collections to store filtered FrameworkMethod instances, not overriding this method caused incorrect return value. The issue is particularly important when using @Category annotations and trying to run only tests methods from specific categories with Surefire. With the current `master` version, if any of the test methods in a test class is marked with the needed category, all the test methods from the class will be tested with surefire. The proposed fix deals with this problem so that only test methods correctly marked with the desired annotation are executed.