### PR TITLE
Make subclassing WebDriverRunner easier

### DIFF
--- a/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
+++ b/src/main/java/com/github/webdriverextensions/junitrunner/WebDriverRunner.java
@@ -155,7 +155,7 @@ public class WebDriverRunner extends BlockJUnit4ClassRunner {
     private final Object childrenLock = new Object();
     private volatile Collection<FrameworkMethod> filteredTestAnnotatedMethods = null; // Guarded by childrenLock
 
-    private Collection<FrameworkMethod> getFilteredTestAnnotatedMethods() {
+    protected Collection<FrameworkMethod> getFilteredTestAnnotatedMethods() {
         if (filteredTestAnnotatedMethods == null) {
             synchronized (childrenLock) {
                 if (filteredTestAnnotatedMethods == null) {


### PR DESCRIPTION
This pull request is related to https://github.com/webdriverextensions/webdriverextensions/pull/105.

While the fix is not merged, I still want to use `WebDriverRunner` via Maven dependency, thus I have to subclass it and introduce the necessary fix. But `getFilteredTestAnnotatedMethods` method is private (just like `ParentRunner#getFilteredChildren`, and it makes it *much* less convenient to override because I have to use reflection. I propose to make `WebDriverRunner` more friendly towards possible customization.