### PR TITLE
By-proxy generation, element list proxy improvement, xpath utility functions, findBy* utility functions, DOM relational functions

### DIFF
--- a/src/main/java/com/github/webdriverextensions/WebDriverExtensionFieldDecorator.java
+++ b/src/main/java/com/github/webdriverextensions/WebDriverExtensionFieldDecorator.java
@@ -1,5 +1,6 @@
 package com.github.webdriverextensions;
 
+import com.github.webdriverextensions.internal.CustomFieldDecorator;
 import com.github.webdriverextensions.internal.WebDriverExtensionAnnotations;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
@@ -22,10 +23,9 @@ import org.openqa.selenium.support.FindAll;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.FindBys;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.pagefactory.DefaultFieldDecorator;
 import org.openqa.selenium.support.pagefactory.ElementLocator;
 
-public class WebDriverExtensionFieldDecorator extends DefaultFieldDecorator {
+public class WebDriverExtensionFieldDecorator extends CustomFieldDecorator {
 
     private final WebDriver driver;
     private final ObjectPool pool;

--- a/src/main/java/com/github/webdriverextensions/internal/ByDecorator.java
+++ b/src/main/java/com/github/webdriverextensions/internal/ByDecorator.java
@@ -1,0 +1,10 @@
+package com.github.webdriverextensions.internal;
+
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public interface ByDecorator {
+    public abstract WebElement decorate(By by);
+    public abstract List<WebElement> decorateList(By by);
+}

--- a/src/main/java/com/github/webdriverextensions/internal/ByDecoratorFactory.java
+++ b/src/main/java/com/github/webdriverextensions/internal/ByDecoratorFactory.java
@@ -1,0 +1,8 @@
+package com.github.webdriverextensions.internal;
+
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriver;
+
+public interface ByDecoratorFactory {
+    public WebDriverExtensionsByDecorator create(SearchContext root, WebDriver driver);
+}

--- a/src/main/java/com/github/webdriverextensions/internal/ByElementLocator.java
+++ b/src/main/java/com/github/webdriverextensions/internal/ByElementLocator.java
@@ -1,0 +1,30 @@
+package com.github.webdriverextensions.internal;
+
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+
+public class ByElementLocator implements ElementLocator {
+
+    private final SearchContext searchContext;
+    private final By by;
+
+    public ByElementLocator(SearchContext searchContext, By by) {
+        this.searchContext = searchContext;
+        this.by = by;
+        
+    }
+
+    @Override
+    public WebElement findElement() {
+        return searchContext.findElement(by);
+    }
+
+    @Override
+    public List<WebElement> findElements() {
+        return  searchContext.findElements(by);
+    }
+
+}

--- a/src/main/java/com/github/webdriverextensions/internal/ByElementLocatorFactory.java
+++ b/src/main/java/com/github/webdriverextensions/internal/ByElementLocatorFactory.java
@@ -1,0 +1,8 @@
+package com.github.webdriverextensions.internal;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+
+public interface ByElementLocatorFactory {
+    public ElementLocator createLocator(By by);
+}

--- a/src/main/java/com/github/webdriverextensions/internal/CustomFieldDecorator.java
+++ b/src/main/java/com/github/webdriverextensions/internal/CustomFieldDecorator.java
@@ -1,0 +1,100 @@
+
+package com.github.webdriverextensions.internal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.List;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.internal.Locatable;
+import org.openqa.selenium.internal.WrapsElement;
+import org.openqa.selenium.support.FindAll;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+import org.openqa.selenium.support.pagefactory.ElementLocatorFactory;
+import org.openqa.selenium.support.pagefactory.FieldDecorator;
+import org.openqa.selenium.support.pagefactory.internal.LocatingElementHandler;
+
+/**
+ * Heavily resembles DefaultFieldDecorator, 
+ * but when decorating list of WebElements, each element is also proxy
+ */
+public class CustomFieldDecorator implements FieldDecorator {
+
+  protected ElementLocatorFactory factory;
+
+  public CustomFieldDecorator(ElementLocatorFactory factory) {
+    this.factory = factory;
+  }
+
+  public Object decorate(ClassLoader loader, Field field) {
+    if (!(WebElement.class.isAssignableFrom(field.getType())
+          || isDecoratableList(field))) {
+      return null;
+    }
+
+    ElementLocator locator = factory.createLocator(field);
+    if (locator == null) {
+      return null;
+    }
+
+    if (WebElement.class.isAssignableFrom(field.getType())) {
+      return proxyForLocator(loader, locator);
+    } else if (List.class.isAssignableFrom(field.getType())) {
+      return proxyForListLocator(loader, locator);
+    } else {
+      return null;
+    }
+  }
+
+  protected boolean isDecoratableList(Field field) {
+    if (!List.class.isAssignableFrom(field.getType())) {
+      return false;
+    }
+
+    // Type erasure in Java isn't complete. Attempt to discover the generic
+    // type of the list.
+    Type genericType = field.getGenericType();
+    if (!(genericType instanceof ParameterizedType)) {
+      return false;
+    }
+
+    Type listType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+
+    if (!WebElement.class.equals(listType)) {
+      return false;
+    }
+
+    if (field.getAnnotation(FindBy.class) == null &&
+        field.getAnnotation(FindBys.class) == null &&
+        field.getAnnotation(FindAll.class) == null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  protected WebElement proxyForLocator(ClassLoader loader, ElementLocator locator) {
+    InvocationHandler handler = new LocatingElementHandler(locator);
+
+    WebElement proxy;
+    proxy = (WebElement) Proxy.newProxyInstance(
+        loader, new Class[]{WebElement.class, WrapsElement.class, Locatable.class}, handler);
+    return proxy;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected List<WebElement> proxyForListLocator(ClassLoader loader, ElementLocator locator) {
+    InvocationHandler handler = new CustomLocatingElementListHandler(locator);
+
+    List<WebElement> proxy;
+    proxy = (List<WebElement>) Proxy.newProxyInstance(
+        loader, new Class[]{List.class}, handler);
+    return proxy;
+  }
+
+}
+

--- a/src/main/java/com/github/webdriverextensions/internal/CustomLocatingElementListHandler.java
+++ b/src/main/java/com/github/webdriverextensions/internal/CustomLocatingElementListHandler.java
@@ -1,0 +1,36 @@
+
+package com.github.webdriverextensions.internal;
+
+import static com.github.webdriverextensions.internal.BotUtils.proxyOf;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomLocatingElementListHandler implements InvocationHandler {
+  private final ElementLocator locator;
+
+  public CustomLocatingElementListHandler(ElementLocator locator) {
+    this.locator = locator;
+  }
+
+  public Object invoke(Object object, Method method, Object[] objects) throws Throwable {
+
+    // selenium doesn't do this for field locators
+    List<WebElement> trueProxy = new ArrayList<>();
+    locator.findElements().forEach((element) -> {
+        trueProxy.add(proxyOf(element));
+    });
+    
+    try {
+      return method.invoke(trueProxy, objects);
+    } catch (InvocationTargetException e) {
+      // Unwrap the underlying exception
+      throw e.getCause();
+    }
+  }
+}

--- a/src/main/java/com/github/webdriverextensions/internal/WebDriverExtensionsByDecorator.java
+++ b/src/main/java/com/github/webdriverextensions/internal/WebDriverExtensionsByDecorator.java
@@ -1,0 +1,48 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.github.webdriverextensions.internal;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.internal.Locatable;
+import org.openqa.selenium.internal.WrapsElement;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+import org.openqa.selenium.support.pagefactory.internal.LocatingElementHandler;
+
+public class WebDriverExtensionsByDecorator implements ByDecorator {
+
+    private final ByElementLocatorFactory factory;
+
+    public WebDriverExtensionsByDecorator(ByElementLocatorFactory factory,
+            WebDriver webDriver) {
+        this.factory = factory;
+    }
+
+    protected WebElement proxyForLocator(ClassLoader loader, ElementLocator locator, By by) {
+        InvocationHandler handler = new LocatingElementHandler(locator);
+        return (WebElement) Proxy.newProxyInstance(loader, new Class[]{WebElement.class, WrapsElement.class, Locatable.class}, handler);
+    }
+
+    protected List<WebElement> proxyForListLocator(ClassLoader loader, ElementLocator locator, By by) {
+        InvocationHandler handler = new CustomLocatingElementListHandler(locator);     
+        return (List<WebElement>) Proxy.newProxyInstance(loader, new Class[]{List.class}, handler);
+    }
+
+    @Override
+    public WebElement decorate(By by) {
+        return proxyForLocator(WebElement.class.getClassLoader(), factory.createLocator(by), by);
+    }
+
+    @Override
+    public List<WebElement> decorateList(By by)  {
+         return proxyForListLocator(ArrayList.class.getClassLoader(), factory.createLocator(by), by);
+    }
+}

--- a/src/main/java/com/github/webdriverextensions/internal/WebDriverExtensionsByDecoratorFactory.java
+++ b/src/main/java/com/github/webdriverextensions/internal/WebDriverExtensionsByDecoratorFactory.java
@@ -1,0 +1,12 @@
+package com.github.webdriverextensions.internal;
+
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriver;
+
+public class WebDriverExtensionsByDecoratorFactory implements ByDecoratorFactory {
+    @Override
+    public WebDriverExtensionsByDecorator create(SearchContext root, WebDriver driver) {
+        return new WebDriverExtensionsByDecorator(
+                new WebDriverExtensionsByElementLocatorFactory(root), driver);
+    }
+}

--- a/src/main/java/com/github/webdriverextensions/internal/WebDriverExtensionsByElementLocatorFactory.java
+++ b/src/main/java/com/github/webdriverextensions/internal/WebDriverExtensionsByElementLocatorFactory.java
@@ -1,0 +1,20 @@
+package com.github.webdriverextensions.internal;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+
+public class WebDriverExtensionsByElementLocatorFactory implements ByElementLocatorFactory {
+
+    private final SearchContext root;
+    
+    public WebDriverExtensionsByElementLocatorFactory(SearchContext root) {
+        this.root = root;
+    }
+
+    @Override
+    public ElementLocator createLocator(By by) {
+        return new ByElementLocator(root, by);
+    }
+
+}


### PR DESCRIPTION
## XPath generation from element
Javascript based. Generates absolute xpath from root of document to target element.
```java

open("http://jkorpela.fi/www/testel.html");
WebElement example1 = driver().findElement(By.className("hyphenate"));
String xpath = xpathOf(example1);
System.out.println("xpath = " + xpath); // xpath = /HTML/BODY[1]/P[20]

```

## Dynamic proxy generation based on existing elements
Using By-decoration and above XPath generation, this enables to create proxy elements based on naked-ones.
```java
open("http://jkorpela.fi/www/testel.html");
WebElement example2 = driver().findElement(By.className("hyphenate"));
WebElement proxy = proxyOf(example2);
navigateRefresh();

System.out.println("textIn(proxy) = " + textIn(proxy));
// textIn(proxy) = Until re­cently the great ma­jor­ity of 
// nat­u­ral­ists be­lieved that species were im­mutable pro­duc­tions, 
// and had been sep­a­rately cre­ated. This view has been ably main­tained by many au­thors.
```

## Initial DOM relationship functions
Simple functions like parent, children, siblings etc.
```java
open("http://jkorpela.fi/www/testel.html");
WebElement example3 = driver().findElement(By.className("hyphenate"));
WebElement parent = parentOf(example3);
WebElement grandParent = parentOf(parent);

System.out.println("isParentOf(parent, example1) = " 
    + isParentOf(parent, example3)); // true
System.out.println("isParentOf(grandParent, parent) = " 
    + isParentOf(grandParent, parent)); // true
System.out.println("isParentOf(grandParent, example1) = " 
    + isParentOf(grandParent, example3)); // false
System.out.println("isDescendandOf(grandParent, example1) = " 
    + isDescendantOf(grandParent, example3)); // true
```
## Page root and Page Object support
Some basic HTML root-oriented functions. May be useful in code like `do { textIn(elem); elem = parentOf(elem); } while(!isPageObject(elem));` or something.
```java
open("http://jkorpela.fi/www/testel.html");
WebElement example4 = driver().findElement(By.tagName("html"));
System.out.println("isDocumentRoot(example4) = " + isDocumentRoot(example4)); // true

if(isPageObjectDefined()) {
    System.out.println("Page Object is defined!");  
    WebElement pageObject = parentOf(example4);  
    System.out.println("isParentOf(pageObject, example4) = " 
            + isParentOf(pageObject, example4)); // true
    try {
        System.out.println("textIn(pageObject) = " + textIn(pageObject)); // exception
    } catch(Exception ex) {
        System.out.println("You can't call functions on Page Object!\n"
                + "Use it only in referential context.");
    }
}
```
## Relative XPath support
This could maybe be useful in WebComponents. Keeping reference to one element, we can find any other element that didn't change position relatively to one we keep.
```java
WebElement example5 = driver().findElement(By.xpath("/html/body/ul[2]/li[22]/sup[6]/sup"));
WebElement another = driver().findElement(By.xpath("/html/body/address[1]/a[2]"));

System.out.println("from example5 to another = " + relativeXPath(example5, another));
    // from example5 to another = ./../../../../ADDRESS[1]/A[2]
System.out.println("from another to example5 = " + relativeXPath(another, example5));
    // from another to example5 = ./../../UL[2]/LI[22]/SUP[6]/SUP[1]
```
## XPath validation
Simple and quick xpath validation using XPathExpression
```java
String example6 = "/html/$$$";
String another = "/html/i/dont/exist/but/am/valid";
System.out.println("isValidXPath(example6) = " + isValidXPath(example6)); // false
System.out.println("isValidXPath(another) = " + isValidXPath(another)); // true
```
## Proxy lists now contain proxy elements
Core change. DefaultFieldDecorator for naked elements created proxy elements, and for naked element lists created proxy lists of naked elements. This change alternates second one, making it create proxy list of proxy elements.
```java
@FindBy(xpath = "html/*")
List<WebElement> elements;

public void run() {
    open("http://jkorpela.fi/www/testel.html");
    WebElement example7 = elements.get(1);

    navigateRefresh(); // before would invalidate example7 
    System.out.println("textIn(example7) = " + textIn(example7)); // works ok, before would throw

}
```
## Proxy-returning findBy* functions
I thought i could write simple function findElement("..."), which would test if argument is valid XPath or Css Selector and perform search, but it appeared to be really hard. Many XPaths are considered valid Css Selectors and vice versa, so some higher logic would be needed here. As alternative, I added multiple functions that return By-decorated proxies, and make it easier to write simple dynamic searches, changing `driver.findElements(By.xpath("/html/body/div[3]/a")` to `findByXPath("html/body/div[3]/a")`, making it shorter and safer.
```java
WebElement example8 = findByXPath("/html/body/address[1]/a[2]");
WebElement another = findByCssSelector("body > address:nth-child(18) > a:nth-child(2)");
        
navigateRefresh();
        
//still ok :)
System.out.println("example8.equals(another) = " + example8.equals(another));
```