### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    	<closeTestReports>true</closeTestReports>
     </properties>
 
     <dependencies>
@@ -383,6 +384,9 @@
                 		<groupId>org.apache.maven.plugins</groupId>
                 		<artifactId>maven-surefire-plugin</artifactId>
                 		<version>${maven-surefire-plugin.version}</version>
+                		<configuration>
+                			<disableXmlReport>${closeTestReports}</disableXmlReport>
+                		</configuration>
             		</plugin>
         		</plugins>
         	</build>
@@ -402,6 +406,7 @@
                     		<!--<parallel>all</parallel>-->
                     		<!--<threadCount>4</threadCount>-->
                     	 	<failIfNoTests>false</failIfNoTests>
+                			<disableXmlReport>${closeTestReports}</disableXmlReport>
                 		</configuration>
             		</plugin>
         		</plugins>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
